### PR TITLE
Fix dependency cache problem for dependencies with long paths

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -133,10 +133,9 @@ jobs:
       # See https://github.com/rudenkornk/docker_cpp_windows
       run: make container
     - name: Cache permissions workaround
+      if: ${{ runner.os == 'Windows' }}
       run: |
-        if [[ '${{ matrix.os }}' =~ 'windows' ]]; then
           make in_docker DOCKER_ADMIN=true COMMAND="icacls $DOCKER_CONAN_CACHE /q /c /t /grant ContainerUser:F"
-        fi
     - name: Install dependecies
       run: make in_docker TARGET=conan
     - name: Configure

--- a/scripts/conanfile.py
+++ b/scripts/conanfile.py
@@ -5,7 +5,6 @@ from conans import ConanFile, CMake
 from conan.tools.cmake import CMakeToolchain
 from conan.tools.cmake import CMakeDeps
 
-
 class CPPContestsConan(ConanFile):
     settings = [
         "arch",

--- a/scripts/makefile_windows
+++ b/scripts/makefile_windows
@@ -83,7 +83,7 @@ DOCKER_ADMIN ?= false
 DOCKER_CONAN_CACHE ?= $$HOME/.conan/data
 DOCKER_ISOLATION ?= hyperv # process or hyperv
 
-DOCKER_IMAGE_TAG := rudenkornk/docker_cpp_windows:0.2.1
+DOCKER_IMAGE_TAG := rudenkornk/docker_cpp_windows:0.2.2
 DOCKER_CONTAINER_NAME := $(PROJECT_NAME)_container
 DOCKER_CONTAINER := $(BUILD_DIR)/$(DOCKER_CONTAINER_NAME)
 DOCKER_CONTAINER_USER != if("$(DOCKER_ADMIN)".ToLower() -ne "true"){return "ContainerUser"}else{return "ContainerAdministrator"}


### PR DESCRIPTION
On Windows Conan creates two directories with cached dependencies:
$HOME/.conan/data and C:/.conan
This is a Conan workaround for Windows short paths problem (which limits
Windows paths to only 260 characters)
Previously C:/.conan directory was not cached in CI, which led to errors
for packages marked as short_paths.